### PR TITLE
This allows cert files to be passed into the Gradio launch

### DIFF
--- a/gradio_gpt_gemini/app.py
+++ b/gradio_gpt_gemini/app.py
@@ -31,6 +31,8 @@ def main():
     parser.add_argument('--user', type=str, help="Username for authentication.")
     parser.add_argument('--password', type=str, help="Password for authentication.")
     parser.add_argument('--debug', action='store_true', help="If set, the app will run in debug mode.")
+    parser.add_argument('--ssl_keyfile', type=str, help="Path to the SSL key file.")
+    parser.add_argument('--ssl_certfile', type=str, help="Path to the SSL certificate file.")
 
     args = parser.parse_args()
 
@@ -116,7 +118,8 @@ def main():
     auth = None
     if args.user and args.password:
         auth = (args.user, args.password)
-    iface.launch(debug=args.debug, share=args.share, auth=auth, server_name=args.listen, server_port=args.port)
+    iface.launch(debug=args.debug, share=args.share, auth=auth, server_name=args.listen, server_port=args.port,
+                 ssl_keyfile=args.ssl_keyfile, ssl_certfile=args.ssl_certfile)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using command line switches to pass in the certs.  I tested this against the branch on the dev server.

I ran into some issues testing this but this code is good.  Be sure to use the `fullchain.pem` cert, otherwise it doesn't work correctly with uvicorn (which is apparently what Gradio uses under the hood).

I also messed up in my startup script and had SSl_CERTFILE one place and SSL_CERTFILE the other place.  It took me a while to track down that error.

