### PR TITLE
Extends timeout for deletion to 180 seconds & adds profiling

### DIFF
--- a/gradio_gpt_gemini/file_reading_util.py
+++ b/gradio_gpt_gemini/file_reading_util.py
@@ -76,7 +76,7 @@ def download_file(url, filename=None):
 
     print(f"File downloaded and saved to: {temp_file_path}")
 
-    # Schedule the file to be removed after 1 minute
-    threading.Timer(60, os.remove, [temp_file_path]).start()
+    # Schedule the file to be removed after 3 minutes
+    threading.Timer(180, os.remove, [temp_file_path]).start()
 
     return temp_file_path

--- a/gradio_gpt_gemini/utils.py
+++ b/gradio_gpt_gemini/utils.py
@@ -12,6 +12,10 @@ import gradio as gr
 import pdb
 import bedrock_llama
 import frictionless_util
+import cProfile
+import pstats
+from io import StringIO
+
 
 def load_profile(profile_name):
     try:
@@ -99,7 +103,17 @@ def process_file_and_return_markdown(file, system_info, prompt, option, input_me
     accum += f"- Processing file: {file_path}\n\n"
     # should be able to work with file_path now in Frictionless data
     if file_path.endswith(('.csv', '.xls', '.xlsx')):
+        profiler = cProfile.Profile()
+        profiler.enable()
         frict_info = frictionless_util.get_output(file_path)
+        profiler.disable()
+
+        # Print the profiling results
+        result = StringIO()
+        ps = pstats.Stats(profiler, stream=result).sort_stats(pstats.SortKey.CUMULATIVE)
+        ps.print_stats()
+        print(result.getvalue())
+
         accum += f'## Report from frictionless data validation\n\n{frict_info}\n\n---\n## Report from LLM\n\n'
         yield accum, accum, "Processing file..."
     else:


### PR DESCRIPTION
The timeout was too short before files were removed with the extra time that frictionless adds.  Extended to 3 minutes from 60 seconds.

Also adds profiling output around the Frictionless call.